### PR TITLE
chore: enhance renovate config with managers, automerge, and labels

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,33 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "schedule": ["on the first day of the month"],
+  "enabledManagers": ["dockerfile", "docker-compose", "poetry"],
+  "prConcurrentLimit": 5,
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "labels": ["dependencies", "patch"]
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "automerge": false,
+      "labels": ["dependencies", "minor"]
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "labels": ["dependencies", "major"]
+    },
+    {
+      "matchCategories": ["security"],
+      "matchSeverity": ["high", "critical"],
+      "schedule": ["at any time"],
+      "automerge": true,
+      "labels": ["security", "high-severity"]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `dockerfile`, `docker-compose`, `poetry` managers
- Schedule monthly checks (1st of each month)
- Auto-merge patch updates; PR-only for minor and major
- Security high/critical: bypass schedule and auto-merge immediately
- Add labels per update type: `patch`, `minor`, `major`, `security`/`high-severity`
- Limit concurrent PRs to 5 (`prConcurrentLimit`)
- Use `platformAutomerge: true` to respect GitHub branch protection rules

## Test plan

- [ ] Verify Renovate runs on the 1st of the month
- [ ] Confirm patch PRs are auto-merged after CI passes
- [ ] Confirm minor/major PRs are created but not auto-merged
- [ ] Confirm security high/critical PRs are created and auto-merged immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)