### PR TITLE
fix: correct invalid Renovate configuration fields

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,8 +24,8 @@
       "labels": ["dependencies", "major"]
     },
     {
-      "matchCategories": ["security"],
-      "matchSeverity": ["high", "critical"],
+      "isVulnerabilityAlert": true,
+      "matchVulnerabilitySeverities": ["high", "critical"],
       "schedule": ["at any time"],
       "automerge": true,
       "labels": ["security", "high-severity"]


### PR DESCRIPTION
## Summary

- Replace invalid `matchCategories: ["security"]` with `isVulnerabilityAlert: true`
- Replace invalid `matchSeverity` with `matchVulnerabilitySeverities`

## Test plan

- [ ] Verify Renovate configuration passes validation after merge
- [ ] Confirm Renovate resumes creating PRs

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)