### PR TITLE
fix: resolve Renovate configuration validation errors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,14 @@
     "config:recommended"
   ],
   "schedule": ["on the first day of the month"],
-  "enabledManagers": ["dockerfile", "docker-compose", "uv"],
+  "enabledManagers": ["dockerfile", "docker-compose", "pep621"],
   "prConcurrentLimit": 5,
   "platformAutomerge": true,
+  "vulnerabilityAlerts": {
+    "schedule": ["at any time"],
+    "automerge": true,
+    "labels": ["security"]
+  },
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],
@@ -22,13 +27,6 @@
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "labels": ["dependencies", "major"]
-    },
-    {
-      "isVulnerabilityAlert": true,
-      "matchVulnerabilitySeverities": ["high", "critical"],
-      "schedule": ["at any time"],
-      "automerge": true,
-      "labels": ["security", "high-severity"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Replace unsupported `uv` manager with `pep621` in `enabledManagers` (uv uses PEP 621 `pyproject.toml`; there is no `uv` manager in Renovate).
- Move security automerge from an invalid `packageRules` entry (using `isVulnerabilityAlert` + `matchVulnerabilitySeverities`, both rejected by `renovate-config-validator`) to the top-level `vulnerabilityAlerts` config.
- Fixes #56.

Note: vulnerability alerts now automerge regardless of severity, since severity-based filtering is not accepted by the installed validator.

## Test plan
- [x] `npx --package renovate -- renovate-config-validator renovate.json` reports `Config validated successfully`

🤖 Generated with [Claude Code](https://claude.com/claude-code)